### PR TITLE
Organize notebooks by plan_name directories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,20 @@ pip install <requirements>
 where `<requirements>` are given by `requirements.txt` in this repo.
 Additionally, the requirements for the specific notebook must be installed.
 
-The notebook(s) run by papermill are located in the directory
+The notebook(s) run by papermill are sorted in directories named by the
+corresponding plan_name:
 
 ```
-/opt/papermill/templates
+/opt/papermill/templates/{plan_name}
 ```
 
 The results generated are placed in the directory
 
 ```
-/opt/papermill/results
+/opt/papermill/results/{plan_name}
 ```
 
-They will be given names like `<notebook-filename-{uid}.ipynb>`.
+They will be given names like `<notebook_filename_{uid}.ipynb>`.
 
 The output directory should be changed in the future! No proper storage is
 currently available, so this is a temporary solution.
@@ -97,7 +98,7 @@ Copy the working copy (likely in a home directory) to the system location where
 the papermill worker looks for it.
 
 ```
-sudo cp path/to/working/copy /opt/papermill/templates/reflection_scan.ipynb
+sudo cp path/to/working/copy /opt/papermill/templates/reflection_scan/my_notebook.ipynb
 ```
 
 It is not necessary to restart the worker; the changes will take effect next

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This kicks off execution of a notebook when a run completes. It is an example of
 "prompt" data analysis.
 
-This is a sketch developed at JPLS. There work to be done to generalize it for
+This is a sketch developed at JPLS. There is work to be done to generalize it for
 wider use.
 
 ## What does this do?
@@ -49,13 +49,13 @@ The notebook(s) run by papermill are sorted in directories named by the
 corresponding plan_name:
 
 ```
-/opt/papermill/templates/{plan_name}
+/opt/bluesky_postprocess/{plan_name}/papermill_templates
 ```
 
 The results generated are placed in the directory
 
 ```
-/opt/papermill/results/{plan_name}
+/opt/bluesky_postprocess/{plan_name}/results
 ```
 
 They will be given names like `<notebook_filename_{uid}.ipynb>`.
@@ -98,7 +98,7 @@ Copy the working copy (likely in a home directory) to the system location where
 the papermill worker looks for it.
 
 ```
-sudo cp path/to/working/copy /opt/papermill/templates/reflection_scan/my_notebook.ipynb
+sudo cp path/to/working/copy /opt/bluesky_postprocess/{plan_name}/papermill_templates/my_notebook.ipynb
 ```
 
 It is not necessary to restart the worker; the changes will take effect next

--- a/papermill_worker.py
+++ b/papermill_worker.py
@@ -1,3 +1,5 @@
+import glob
+import os
 import sys
 
 from event_model import RunRouter
@@ -5,19 +7,34 @@ from bluesky.callbacks.zmq import RemoteDispatcher
 import papermill
 
 
+BASE_PATH = '/opt/papermill/'
+TEMPLATE_PATH = os.path.join(BASE_PATH, 'templates')
+OUTPUT_PATH = os.path.join(BASE_PATH, 'results')
+
+
 def factory(name, start_doc):
     plan_name = start_doc.get('plan_name')
     uid = start_doc['uid']
     callbacks = []
-    if plan_name == 'reflection_scan':
-        def callback(name, doc):
-            if name == 'stop':
-                papermill.execute_notebook(
-                    '/opt/papermill/templates/reflection_scan.ipynb',
-                    f"/opt/papermill/results/reflection_scan_{uid}.ipynb",
-                    dict(uid=uid))
+    input_directory = os.path.join(TEMPLATE_PATH, plan_name)
+    if os.path.isdir(input_directory):
+        for input_path in glob.glob(os.path.join(input_directory, '*.ipynb')):
+            basename = os.path.basename(input_path)
+            filename, ext = os.path.splitext(basename)
+            output_path = os.path.join(
+                OUTPUT_PATH,
+                plan_name,
+                f'{filename}_{uid}{ext}')
+
+            def callback(name, doc):
+                if name == 'stop':
+                    papermill.execute_notebook(
+                        input_path,
+                        output_path,
+                        dict(uid=uid))
+
         callbacks.append(callback)
-    else:
+    if not callbacks:
         print("Nothing to do for Run with uid={uid!r} "
               "and plan_name={plan_name!r}", file=sys.stderr)
 

--- a/papermill_worker.py
+++ b/papermill_worker.py
@@ -7,8 +7,8 @@ from bluesky.callbacks.zmq import RemoteDispatcher
 import papermill
 
 
-BASE_PATH = '/opt/papermill/'
-TEMPLATE_PATH = os.path.join(BASE_PATH, 'templates')
+BASE_PATH = '/opt/bluesky_postprocess/{plan_name}'
+TEMPLATE_PATH = os.path.join(BASE_PATH, 'papermill_templates')
 OUTPUT_PATH = os.path.join(BASE_PATH, 'results')
 
 
@@ -16,14 +16,13 @@ def factory(name, start_doc):
     plan_name = start_doc.get('plan_name')
     uid = start_doc['uid']
     callbacks = []
-    input_directory = os.path.join(TEMPLATE_PATH, plan_name)
+    input_directory = TEMPLATE_PATH.format(plan_name)
     if os.path.isdir(input_directory):
         for input_path in glob.glob(os.path.join(input_directory, '*.ipynb')):
             basename = os.path.basename(input_path)
             filename, ext = os.path.splitext(basename)
             output_path = os.path.join(
-                OUTPUT_PATH,
-                plan_name,
+                OUTPUT_PATH.format(plan_name),
                 f'{filename}_{uid}{ext}')
 
             def callback(name, doc):


### PR DESCRIPTION
Instead of hard-coding the `plan_name` `'reflection_scan'`, look for a subdirectory matching the `plan_name`, whatever it is, and execute any notebooks therein.